### PR TITLE
Auto-detect ejb-remote [SWARM-520]

### DIFF
--- a/fraction-list/src/main/resources/org/wildfly/swarm/fractionlist/fraction-packages.properties
+++ b/fraction-list/src/main/resources/org/wildfly/swarm/fractionlist/fraction-packages.properties
@@ -1,10 +1,12 @@
-# packages can be foo+bar, if both are required to activate the fraction, or foo,bar if either will requires the fraction
+# matchers can be foo+bar, if both are required to activate the fraction, or foo,bar if either will requires the fraction
 # can be mixed and matched: some-fraction=foo+bar,baz, with + taking precedence
 # If the package ends with *, it is checked as a prefix
+# specific-class matchers can be specified with foo.bar:ClassName
 batch-jberet=javax.batch
 bean-validation=javax.validation*
 cdi=javax.inject,javax.enterprise.inject,javax.enterprise.context,javax.enterprise.event
 ejb=javax.ejb
+ejb-remote=javax.ejb:Remote
 infinispan=org.infinispan
 javafx=javafx*
 jaxrs=javax.ws.rs


### PR DESCRIPTION
Now that fraction detection supports detecting based on specific
classes, we can auto-detect ejb-remote.